### PR TITLE
v2.1.3

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -611,7 +611,7 @@ jQuery(
                     if (showPlaceOrderButton) {
                         placeOrderButton.style.display = '';
                     } else {
-                        placeOrderButton.style.display = 'none';
+                        placeOrderButton.style.setProperty('display', 'none', 'important');
                     }
                 }
             },

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -31,6 +31,7 @@ use UnzerPayments\Gateways\WeChatPay;
 use UnzerPayments\Gateways\Wero;
 use UnzerPayments\Services\DashboardService;
 use UnzerPayments\Services\OrderService;
+use UnzerPayments\Services\PaymentService;
 use WC_Payment_Gateway;
 
 class Main {
@@ -46,6 +47,7 @@ class Main {
 	const ORDER_META_KEY_CANCELLATION_ID      = 'unzer_cancellation_id';
 	const ORDER_META_KEY_DATE_OF_BIRTH        = 'unzer_dob';
 	const ORDER_META_KEY_COMPANY_TYPE         = 'unzer_company_type';
+    const ORDER_CHARGE_AUTOMATICALLY_DONE     = 'unzer_charge_automatically_done';
 	const ORDER_META_KEYS                     = array(
 		self::ORDER_META_KEY_AUTHORIZATION_ID,
 		self::ORDER_META_KEY_CHARGE_ID,
@@ -101,6 +103,7 @@ class Main {
 		add_action( 'admin_notices', array( new DashboardService(), 'showNotifications' ) );
 		add_action( 'woocommerce_blocks_loaded', array( $this, 'addCheckoutBlocks' ) );
 		add_action( 'before_woocommerce_pay_form', array( $this, 'orderPayPaymentMethod' ), 20, 4 );
+        add_action( 'woocommerce_order_status_changed', array($this, 'unzerPaymentStatusChange'), 10, 4);
 		add_action(
 			'admin_enqueue_scripts',
 			function () {
@@ -324,6 +327,25 @@ class Main {
 					'value'   => get_option( 'unzer_chargeback_order_status' ),
 					'default' => OrderService::ORDER_STATUS_CHARGEBACK,
 				),
+                'capture_trigger_order_status' => array(
+                    'title'   => __( 'Order status to trigger capture', 'unzer-payments' ),
+                    'label'   => '',
+                    'type'    => 'select',
+                    'desc'    => __( 'This status triggers an automatic capture action', 'unzer-payments' ),
+                    'options' => array_merge( array( '' => __( '[No automatic capture]', 'unzer-payments' ) ), wc_get_order_statuses() ),
+                    'id'      => 'unzer_capture_trigger_order_status',
+                    'value'   => get_option( 'unzer_capture_trigger_order_status' ),
+                    'default' => '',
+                ),
+                'capture_order_status_lock' => array(
+                    'title'   => __( 'Lock order state', 'unzer-payments' ),
+                    'label'   => '',
+                    'type'    => 'checkbox',
+                    'desc'    => __( 'When checked, order state will not change to order state defined in “Order status for captured payments” after automatic capture.', 'unzer-payments' ),
+                    'id'      => 'unzer_capture_order_status_lock',
+                    'value'   => get_option( 'unzer_capture_order_status_lock' ),
+                    'default' => '',
+                ),
 				'sectionend'              => array(
 					'type' => 'sectionend',
 				),
@@ -376,6 +398,36 @@ class Main {
 		}
 		return null;
 	}
+
+    public function unzerPaymentStatusChange($order_id, $from, $to, $order)
+    {
+        if (!AbstractGateway::isUnzerPaymentMethod($order->get_payment_method())) {
+            return;
+        }
+        if ( $order->get_payment_method() === Prepayment::GATEWAY_ID ) {
+            return;
+        }
+        if ( $order->get_payment_method() === OpenBanking::GATEWAY_ID ) {
+            return;
+        }
+
+        try {
+            if (in_array($to, [str_replace('wc-', '', get_option( 'unzer_capture_trigger_order_status' ))], true)) {
+                if (!$order->is_paid()) {
+                    $unzer        = ( new PaymentService() )->getUnzerManagerForOrder( $order );
+                    $paymentId = $order->get_meta( Main::ORDER_META_KEY_PAYMENT_ID, true );
+                    $payment      = $unzer->fetchPayment( $paymentId );
+                    if ( $payment->getAmount()->getCharged() == 0 ) {
+                        $order->update_meta_data( Main::ORDER_CHARGE_AUTOMATICALLY_DONE, 'yes' );
+                        $order->save_meta_data();
+                        ( new PaymentService() )->performChargeOnAuthorization( $order_id );
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            // silent
+        }
+    }
 
 	public function addCheckoutBlocks() {
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {

--- a/includes/controllers/WebhookController.php
+++ b/includes/controllers/WebhookController.php
@@ -2,6 +2,9 @@
 
 namespace UnzerPayments\Controllers;
 
+use UnzerPayments\Gateways\OpenBanking;
+use UnzerPayments\Gateways\Prepayment;
+use UnzerPayments\Main;
 use UnzerPayments\Services\DashboardService;
 use UnzerPayments\Services\LogService;
 use UnzerPayments\Services\OrderService;
@@ -174,10 +177,40 @@ class WebhookController {
 			)
 		);
 		$order = wc_get_order( $orderId );
-		$order->payment_complete( $paymentId );
+        $previous_status = $order->get_status();
+        $order->payment_complete( $paymentId );
 		$order->set_transaction_id( $paymentId );
 		if ( get_option( 'unzer_captured_order_status' ) ) {
-			$order->set_status( get_option( 'unzer_captured_order_status' ) );
+            $update_order_status = true;
+            if ( get_option( 'unzer_capture_order_status_lock' ) === 'yes' ) {
+                if ($order->get_meta( Main::ORDER_CHARGE_AUTOMATICALLY_DONE) === 'yes') {
+                    $update_order_status = false;
+                }
+            }
+            if (get_option( 'unzer_capture_trigger_order_status' )) {
+                $triggerStatus = str_replace(
+                    'wc-',
+                    '',
+                    get_option( 'unzer_capture_trigger_order_status' )
+                );
+
+                if (
+                    in_array(
+                        $order->get_payment_method(),
+                        array(
+                            Prepayment::GATEWAY_ID,
+                            OpenBanking::GATEWAY_ID,
+                        ),
+                        true
+                    )
+                ) {
+                    $update_order_status = false;
+                }
+            }
+
+            if ($update_order_status) {
+                $order->set_status( str_replace( 'wc-', '', get_option( 'unzer_captured_order_status' ) ) );
+            }
 		}
 		$order->save();
 	}

--- a/includes/gateways/AbstractGateway.php
+++ b/includes/gateways/AbstractGateway.php
@@ -148,7 +148,7 @@ abstract class AbstractGateway extends WC_Payment_Gateway {
 	}
 
 	public function needs_setup() {
-		return true;
+		return false;
 	}
 
 	public function is_enabled() {

--- a/includes/gateways/Blocks/AbstractBlock.php
+++ b/includes/gateways/Blocks/AbstractBlock.php
@@ -92,11 +92,52 @@ abstract class AbstractBlock extends AbstractPaymentMethodType {
 	}
 
 	public function get_payment_method_script_handles() {
+        if (is_admin()) {
+            $identifier               = $this->get_identifier();
+            $asset_handle             = $identifier . '-block-checkout';
+            $script_dependencies_path = UNZER_PLUGIN_PATH . 'assets/build/' . $identifier . '.asset.php';
+            $script_url               = UNZER_PLUGIN_URL . '/assets/build/' . $identifier . '.js';
+
+            if ( file_exists( $script_dependencies_path ) ) {
+                $script_dependencies = require $script_dependencies_path;
+
+                if ( ! wp_script_is( 'unzer_global-block-checkout', 'registered' ) ) {
+                    wp_register_script(
+                        'unzer_global-block-checkout',
+                        UNZER_PLUGIN_URL . '/assets/build/unzer_global.js',
+                        array( 'wc-blocks-registry', 'wc-settings', 'wp-element', 'wp-html-entities', 'wp-i18n' ),
+                        UNZER_VERSION,
+                        true
+                    );
+                }
+
+                $dependencies = array_unique(
+                    array_merge(
+                        array( 'unzer_global-block-checkout' ),
+                        $script_dependencies['dependencies']
+                    )
+                );
+
+                if ( ! wp_script_is( $asset_handle, 'registered' ) ) {
+                    wp_register_script(
+                        $asset_handle,
+                        $script_url,
+                        $dependencies,
+                        $script_dependencies['version'],
+                        true
+                    );
+
+                    wp_set_script_translations( $asset_handle, 'unzer-payments' );
+                }
+            }
+
+            return array( $asset_handle );
+        }
 		return array( $this->get_identifier() . '-block-checkout' );
 	}
 
 	public function get_payment_method_script_handles_for_admin() {
-		return array();
+		return $this->get_payment_method_script_handles();
 	}
 
 

--- a/includes/gateways/GooglePay.php
+++ b/includes/gateways/GooglePay.php
@@ -247,4 +247,11 @@ class GooglePay extends AbstractGateway {
 		}
 		return $return;
 	}
+
+    public function needs_setup() {
+        if ($this->get_option( 'merchant_id' ) == '' || $this->get_option( 'merchant_name' ) == '' ) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzer-payments",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Unzer
 Tags: payments, woocommerce
 Requires at least: 4.5
 Tested up to: 6.9
-Stable tag: 2.1.2
+Stable tag: 2.1.3
 License: Apache-2.0
 License URI: http://www.apache.org/licenses/LICENSE-2.0
 Author URI: https://unzer.com
@@ -58,6 +58,12 @@ Personal support via e-mail to support@unzer.com or +49 (6221) 43101-00
 Unzer is one of the leading payment companies in Europe. Over 70,000 retailers trust in the end-to-end solutions for more growth * online, mobile or at the point of sale. Whether international payment processing, risk management or analysis of customer behavior: merchants can put together the data-driven services in a modular way. This means that merchants only need one partner to make their payment future-proof, flexible and innovative.
 
 ## Changelog ##
+
+# 2.1.3 #
+* Fixed order button incorrectly displayed alongside Apple Pay and Google Pay
+* Fixed “Blocks not supported” message appearing in the designer
+* Improvement: Fixed error when enabling a payment method from the payment overview
+* Improvement: Added support for capturing payment when order status is changed to shipped
 
 # 2.1.2 #
 * Removed country restrictions for Direct Bank Transfer

--- a/unzer-payments.php
+++ b/unzer-payments.php
@@ -5,12 +5,12 @@
  * Description: Official Unzer Plugin
  * Author: Unzer
  * Author URI: https://www.unzer.com
- * Version: 2.1.2
+ * Version: 2.1.3
  * License: Apache-2.0
  * Requires at least: 4.5
  * Tested up to: 6.9
  * WC requires at least: 6.0
- * WC tested up to: 10.4
+ * WC tested up to: 10.7
  * Text Domain: unzer-payments
  */
 
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'UNZER_VERSION', '2.1.2' );
+define( 'UNZER_VERSION', '2.1.3' );
 define( 'UNZER_PLUGIN_TYPE_STRING', 'Unzer Payments' );
 define( 'UNZER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'UNZER_PLUGIN_PATH', __DIR__ . '/' );


### PR DESCRIPTION
* Fixed order button incorrectly displayed alongside Apple Pay and Google Pay
* Fixed “Blocks not supported” message appearing in the designer
* Improvement: Fixed error when enabling a payment method from the payment overview
* Improvement: Added support for capturing payment when order status is changed to shipped