### PR TITLE
v2.1.4

### DIFF
--- a/html/admin/transactions.php
+++ b/html/admin/transactions.php
@@ -108,7 +108,7 @@ ob_start();
 				document.getElementById('unzer-totals-row').innerHTML = totalsHtml;
 
 				let captureHtml = '';
-				if (data.remainingPlain && data.paymentMethod !== 'unzer_prepayment' && data.status !== 'canceled') {
+				if (data.remainingPlain && data.paymentMethod !== 'unzer_prepayment' && data.paymentMethod !== 'unzer_open_banking' && data.status !== 'canceled') {
 					captureHtml = `<input type="number" step="0.01" min="0.01" max="${data.remainingPlain}" value="${data.remainingPlain}" id="unzer-capture-amount-input" />
 						<a href="#" id="unzer-capture-btn" onclick="unzerCaptureOrder(unzerOrderId, document.getElementById('unzer-capture-amount-input').value, '<?php echo esc_attr( Util::getNonce() ); ?>'); return false;" class="button button-small"><?php echo esc_html__( 'Capture', 'unzer-payments' ); ?></a>`;
 				}

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -47,7 +47,7 @@ class Main {
 	const ORDER_META_KEY_CANCELLATION_ID      = 'unzer_cancellation_id';
 	const ORDER_META_KEY_DATE_OF_BIRTH        = 'unzer_dob';
 	const ORDER_META_KEY_COMPANY_TYPE         = 'unzer_company_type';
-    const ORDER_CHARGE_AUTOMATICALLY_DONE     = 'unzer_charge_automatically_done';
+	const ORDER_CHARGE_AUTOMATICALLY_DONE     = 'unzer_charge_automatically_done';
 	const ORDER_META_KEYS                     = array(
 		self::ORDER_META_KEY_AUTHORIZATION_ID,
 		self::ORDER_META_KEY_CHARGE_ID,
@@ -103,7 +103,7 @@ class Main {
 		add_action( 'admin_notices', array( new DashboardService(), 'showNotifications' ) );
 		add_action( 'woocommerce_blocks_loaded', array( $this, 'addCheckoutBlocks' ) );
 		add_action( 'before_woocommerce_pay_form', array( $this, 'orderPayPaymentMethod' ), 20, 4 );
-        add_action( 'woocommerce_order_status_changed', array($this, 'unzerPaymentStatusChange'), 10, 4);
+		add_action( 'woocommerce_order_status_changed', array( $this, 'unzerPaymentStatusChange' ), 10, 4 );
 		add_action(
 			'admin_enqueue_scripts',
 			function () {
@@ -277,11 +277,11 @@ class Main {
 				update_option( 'unzer_authorized_order_status', OrderService::ORDER_STATUS_AUTHORIZED );
 			}
 			$settings = array(
-				'title'                   => array(
+				'title'                        => array(
 					'type' => 'title',
 					'desc' => '',
 				),
-				'public_key'              => array(
+				'public_key'                   => array(
 					'title'   => __( 'Public Key', 'unzer-payments' ),
 					'type'    => 'text',
 					'desc'    => '',
@@ -289,7 +289,7 @@ class Main {
 					'value'   => get_option( 'unzer_public_key' ),
 					'default' => '',
 				),
-				'private_key'             => array(
+				'private_key'                  => array(
 					'title'   => __( 'Private Key', 'unzer-payments' ),
 					'type'    => 'text',
 					'desc'    => '',
@@ -297,7 +297,7 @@ class Main {
 					'value'   => get_option( 'unzer_private_key' ),
 					'default' => '',
 				),
-				'authorized_order_status' => array(
+				'authorized_order_status'      => array(
 					'title'   => __( 'Order status for authorized payments', 'unzer-payments' ),
 					'label'   => '',
 					'type'    => 'select',
@@ -307,7 +307,7 @@ class Main {
 					'value'   => get_option( 'unzer_authorized_order_status' ),
 					'default' => OrderService::ORDER_STATUS_AUTHORIZED,
 				),
-				'captured_order_status'   => array(
+				'captured_order_status'        => array(
 					'title'   => __( 'Order status for captured payments', 'unzer-payments' ),
 					'label'   => '',
 					'type'    => 'select',
@@ -317,7 +317,7 @@ class Main {
 					'value'   => get_option( 'unzer_captured_order_status' ),
 					'default' => '',
 				),
-				'chargeback_order_status' => array(
+				'chargeback_order_status'      => array(
 					'title'   => __( 'Order status for chargebacks', 'unzer-payments' ),
 					'label'   => '',
 					'type'    => 'select',
@@ -327,26 +327,26 @@ class Main {
 					'value'   => get_option( 'unzer_chargeback_order_status' ),
 					'default' => OrderService::ORDER_STATUS_CHARGEBACK,
 				),
-                'capture_trigger_order_status' => array(
-                    'title'   => __( 'Order status to trigger capture', 'unzer-payments' ),
-                    'label'   => '',
-                    'type'    => 'select',
-                    'desc'    => __( 'This status triggers an automatic capture action', 'unzer-payments' ),
-                    'options' => array_merge( array( '' => __( '[No automatic capture]', 'unzer-payments' ) ), wc_get_order_statuses() ),
-                    'id'      => 'unzer_capture_trigger_order_status',
-                    'value'   => get_option( 'unzer_capture_trigger_order_status' ),
-                    'default' => '',
-                ),
-                'capture_order_status_lock' => array(
-                    'title'   => __( 'Lock order state', 'unzer-payments' ),
-                    'label'   => '',
-                    'type'    => 'checkbox',
-                    'desc'    => __( 'When checked, order state will not change to order state defined in “Order status for captured payments” after automatic capture.', 'unzer-payments' ),
-                    'id'      => 'unzer_capture_order_status_lock',
-                    'value'   => get_option( 'unzer_capture_order_status_lock' ),
-                    'default' => '',
-                ),
-				'sectionend'              => array(
+				'capture_trigger_order_status' => array(
+					'title'   => __( 'Order status to trigger capture', 'unzer-payments' ),
+					'label'   => '',
+					'type'    => 'select',
+					'desc'    => __( 'This status triggers an automatic capture action', 'unzer-payments' ),
+					'options' => array_merge( array( '' => __( '[No automatic capture]', 'unzer-payments' ) ), wc_get_order_statuses() ),
+					'id'      => 'unzer_capture_trigger_order_status',
+					'value'   => get_option( 'unzer_capture_trigger_order_status' ),
+					'default' => '',
+				),
+				'capture_order_status_lock'    => array(
+					'title'   => __( 'Lock order state', 'unzer-payments' ),
+					'label'   => '',
+					'type'    => 'checkbox',
+					'desc'    => __( 'When checked, order state will not change to order state defined in “Order status for captured payments” after automatic capture.', 'unzer-payments' ),
+					'id'      => 'unzer_capture_order_status_lock',
+					'value'   => get_option( 'unzer_capture_order_status_lock' ),
+					'default' => '',
+				),
+				'sectionend'                   => array(
 					'type' => 'sectionend',
 				),
 			);
@@ -399,35 +399,34 @@ class Main {
 		return null;
 	}
 
-    public function unzerPaymentStatusChange($order_id, $from, $to, $order)
-    {
-        if (!AbstractGateway::isUnzerPaymentMethod($order->get_payment_method())) {
-            return;
-        }
-        if ( $order->get_payment_method() === Prepayment::GATEWAY_ID ) {
-            return;
-        }
-        if ( $order->get_payment_method() === OpenBanking::GATEWAY_ID ) {
-            return;
-        }
+	public function unzerPaymentStatusChange( $order_id, $from, $to, $order ) {
+		if ( ! AbstractGateway::isUnzerPaymentMethod( $order->get_payment_method() ) ) {
+			return;
+		}
+		if ( $order->get_payment_method() === Prepayment::GATEWAY_ID ) {
+			return;
+		}
+		if ( $order->get_payment_method() === OpenBanking::GATEWAY_ID ) {
+			return;
+		}
 
-        try {
-            if (in_array($to, [str_replace('wc-', '', get_option( 'unzer_capture_trigger_order_status' ))], true)) {
-                if (!$order->is_paid()) {
-                    $unzer        = ( new PaymentService() )->getUnzerManagerForOrder( $order );
-                    $paymentId = $order->get_meta( Main::ORDER_META_KEY_PAYMENT_ID, true );
-                    $payment      = $unzer->fetchPayment( $paymentId );
-                    if ( $payment->getAmount()->getCharged() == 0 ) {
-                        $order->update_meta_data( Main::ORDER_CHARGE_AUTOMATICALLY_DONE, 'yes' );
-                        $order->save_meta_data();
-                        ( new PaymentService() )->performChargeOnAuthorization( $order_id );
-                    }
-                }
-            }
-        } catch (\Exception $e) {
-            // silent
-        }
-    }
+		try {
+			if ( in_array( $to, array( str_replace( 'wc-', '', get_option( 'unzer_capture_trigger_order_status' ) ) ), true ) ) {
+				if ( ! $order->is_paid() ) {
+					$unzer     = ( new PaymentService() )->getUnzerManagerForOrder( $order );
+					$paymentId = $order->get_meta( self::ORDER_META_KEY_PAYMENT_ID, true );
+					$payment   = $unzer->fetchPayment( $paymentId );
+					if ( $payment->getAmount()->getCharged() == 0 ) {
+						$order->update_meta_data( self::ORDER_CHARGE_AUTOMATICALLY_DONE, 'yes' );
+						$order->save_meta_data();
+						( new PaymentService() )->performChargeOnAuthorization( $order_id );
+					}
+				}
+			}
+		} catch ( \Exception $e ) {
+			// silent
+		}
+	}
 
 	public function addCheckoutBlocks() {
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {

--- a/includes/controllers/WebhookController.php
+++ b/includes/controllers/WebhookController.php
@@ -58,7 +58,6 @@ class WebhookController {
 					'msg'     => 'event not relevant',
 				)
 			);
-			die;
 		}
 
 		// TODO: evaluate if we have better options to prevent the race condition
@@ -176,41 +175,41 @@ class WebhookController {
 				'orderId'   => $orderId,
 			)
 		);
-		$order = wc_get_order( $orderId );
-        $previous_status = $order->get_status();
-        $order->payment_complete( $paymentId );
+		$order           = wc_get_order( $orderId );
+		$previous_status = $order->get_status();
+		$order->payment_complete( $paymentId );
 		$order->set_transaction_id( $paymentId );
 		if ( get_option( 'unzer_captured_order_status' ) ) {
-            $update_order_status = true;
-            if ( get_option( 'unzer_capture_order_status_lock' ) === 'yes' ) {
-                if ($order->get_meta( Main::ORDER_CHARGE_AUTOMATICALLY_DONE) === 'yes') {
-                    $update_order_status = false;
-                }
-            }
-            if (get_option( 'unzer_capture_trigger_order_status' )) {
-                $triggerStatus = str_replace(
-                    'wc-',
-                    '',
-                    get_option( 'unzer_capture_trigger_order_status' )
-                );
+			$update_order_status = true;
+			if ( get_option( 'unzer_capture_order_status_lock' ) === 'yes' ) {
+				if ( $order->get_meta( Main::ORDER_CHARGE_AUTOMATICALLY_DONE ) === 'yes' ) {
+					$update_order_status = false;
+				}
+			}
+			if ( get_option( 'unzer_capture_trigger_order_status' ) ) {
+				$triggerStatus = str_replace(
+					'wc-',
+					'',
+					get_option( 'unzer_capture_trigger_order_status' )
+				);
 
-                if (
-                    in_array(
-                        $order->get_payment_method(),
-                        array(
-                            Prepayment::GATEWAY_ID,
-                            OpenBanking::GATEWAY_ID,
-                        ),
-                        true
-                    )
-                ) {
-                    $update_order_status = false;
-                }
-            }
+				if (
+					in_array(
+						$order->get_payment_method(),
+						array(
+							Prepayment::GATEWAY_ID,
+							OpenBanking::GATEWAY_ID,
+						),
+						true
+					)
+				) {
+					$update_order_status = false;
+				}
+			}
 
-            if ($update_order_status) {
-                $order->set_status( str_replace( 'wc-', '', get_option( 'unzer_captured_order_status' ) ) );
-            }
+			if ( $update_order_status ) {
+				$order->set_status( str_replace( 'wc-', '', get_option( 'unzer_captured_order_status' ) ) );
+			}
 		}
 		$order->save();
 	}

--- a/includes/gateways/Blocks/AbstractBlock.php
+++ b/includes/gateways/Blocks/AbstractBlock.php
@@ -52,19 +52,19 @@ abstract class AbstractBlock extends AbstractPaymentMethodType {
 		/** @var AbstractGateway $gateway */
 		$gateway = new $gatewayClass();
 		return array(
-			'id'                 => static::GATEWAY_ID,
-			'title'              => $gateway->title,
-			'description'        => $gateway->description,
-			'allowedCountries'   => $gateway->allowedCountries,
-			'allowedCurrencies'  => $gateway->allowedCurrencies,
-			'publicKey'          => $gateway->get_public_key(),
-			'locale'             => get_locale(),
-			'nonce'              => Util::getNonce(),
+			'id'                  => static::GATEWAY_ID,
+			'title'               => $gateway->title,
+			'description'         => $gateway->description,
+			'allowedCountries'    => $gateway->allowedCountries,
+			'allowedCurrencies'   => $gateway->allowedCurrencies,
+			'publicKey'           => $gateway->get_public_key(),
+			'locale'              => get_locale(),
+			'nonce'               => Util::getNonce(),
 			'storeName'           => get_bloginfo( 'name' ),
 			'storeCountry'        => strtoupper( substr( get_option( 'woocommerce_default_country' ), 0, 2 ) ),
-			'paymentComponentId' => str_replace( '_', '-', static::GATEWAY_ID ) . '-payment-component',
+			'paymentComponentId'  => str_replace( '_', '-', static::GATEWAY_ID ) . '-payment-component',
 			'checkoutComponentId' => str_replace( '_', '-', static::GATEWAY_ID ) . '-checkout-component',
-			'getCustomerDataUrl' => WC()->api_request_url( CheckoutController::GET_UNZER_CUSTOMER_SLUG ),
+			'getCustomerDataUrl'  => WC()->api_request_url( CheckoutController::GET_UNZER_CUSTOMER_SLUG ),
 		);
 	}
 
@@ -92,47 +92,47 @@ abstract class AbstractBlock extends AbstractPaymentMethodType {
 	}
 
 	public function get_payment_method_script_handles() {
-        if (is_admin()) {
-            $identifier               = $this->get_identifier();
-            $asset_handle             = $identifier . '-block-checkout';
-            $script_dependencies_path = UNZER_PLUGIN_PATH . 'assets/build/' . $identifier . '.asset.php';
-            $script_url               = UNZER_PLUGIN_URL . '/assets/build/' . $identifier . '.js';
+		if ( is_admin() ) {
+			$identifier               = $this->get_identifier();
+			$asset_handle             = $identifier . '-block-checkout';
+			$script_dependencies_path = UNZER_PLUGIN_PATH . 'assets/build/' . $identifier . '.asset.php';
+			$script_url               = UNZER_PLUGIN_URL . '/assets/build/' . $identifier . '.js';
 
-            if ( file_exists( $script_dependencies_path ) ) {
-                $script_dependencies = require $script_dependencies_path;
+			if ( file_exists( $script_dependencies_path ) ) {
+				$script_dependencies = require $script_dependencies_path;
 
-                if ( ! wp_script_is( 'unzer_global-block-checkout', 'registered' ) ) {
-                    wp_register_script(
-                        'unzer_global-block-checkout',
-                        UNZER_PLUGIN_URL . '/assets/build/unzer_global.js',
-                        array( 'wc-blocks-registry', 'wc-settings', 'wp-element', 'wp-html-entities', 'wp-i18n' ),
-                        UNZER_VERSION,
-                        true
-                    );
-                }
+				if ( ! wp_script_is( 'unzer_global-block-checkout', 'registered' ) ) {
+					wp_register_script(
+						'unzer_global-block-checkout',
+						UNZER_PLUGIN_URL . '/assets/build/unzer_global.js',
+						array( 'wc-blocks-registry', 'wc-settings', 'wp-element', 'wp-html-entities', 'wp-i18n' ),
+						UNZER_VERSION,
+						true
+					);
+				}
 
-                $dependencies = array_unique(
-                    array_merge(
-                        array( 'unzer_global-block-checkout' ),
-                        $script_dependencies['dependencies']
-                    )
-                );
+				$dependencies = array_unique(
+					array_merge(
+						array( 'unzer_global-block-checkout' ),
+						$script_dependencies['dependencies']
+					)
+				);
 
-                if ( ! wp_script_is( $asset_handle, 'registered' ) ) {
-                    wp_register_script(
-                        $asset_handle,
-                        $script_url,
-                        $dependencies,
-                        $script_dependencies['version'],
-                        true
-                    );
+				if ( ! wp_script_is( $asset_handle, 'registered' ) ) {
+					wp_register_script(
+						$asset_handle,
+						$script_url,
+						$dependencies,
+						$script_dependencies['version'],
+						true
+					);
 
-                    wp_set_script_translations( $asset_handle, 'unzer-payments' );
-                }
-            }
+					wp_set_script_translations( $asset_handle, 'unzer-payments' );
+				}
+			}
 
-            return array( $asset_handle );
-        }
+			return array( $asset_handle );
+		}
 		return array( $this->get_identifier() . '-block-checkout' );
 	}
 

--- a/includes/gateways/DirectDebitSecured.php
+++ b/includes/gateways/DirectDebitSecured.php
@@ -97,8 +97,8 @@ class DirectDebitSecured extends AbstractGateway {
 					'default'     => '',
 				),
 				'additional_key_info' => array(
-					'type' => 'unzer_additional_key_info',
-                    'default'     => '',
+					'type'    => 'unzer_additional_key_info',
+					'default' => '',
 				),
 				'public_key_eur_b2c'  => array(
 					'title'   => __( 'Public Key EUR/B2C', 'unzer-payments' ),
@@ -141,8 +141,8 @@ class DirectDebitSecured extends AbstractGateway {
 			}
 		);
 		$this->before_payment_redirect( $order_id );
-		if ( $authorization->getPayment()->getRedirectUrl() ) {
-			$return['redirect'] = $authorization->getPayment()->getRedirectUrl();
+		if ( $authorization->getRedirectUrl() ) {
+			$return['redirect'] = $authorization->getRedirectUrl();
 		} elseif ( $authorization->isSuccess() ) {
 			try {
 				// this is repeated in confirmAction, but we need to make sure, that the order is updated if anything goes wrong

--- a/includes/gateways/GooglePay.php
+++ b/includes/gateways/GooglePay.php
@@ -248,10 +248,10 @@ class GooglePay extends AbstractGateway {
 		return $return;
 	}
 
-    public function needs_setup() {
-        if ($this->get_option( 'merchant_id' ) == '' || $this->get_option( 'merchant_name' ) == '' ) {
-            return true;
-        }
-        return false;
-    }
+	public function needs_setup() {
+		if ( $this->get_option( 'merchant_id' ) == '' || $this->get_option( 'merchant_name' ) == '' ) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/includes/gateways/Installment.php
+++ b/includes/gateways/Installment.php
@@ -105,8 +105,8 @@ class Installment extends AbstractGateway {
 					'default'     => '',
 				),
 				'additional_key_info' => array(
-					'type' => 'unzer_additional_key_info',
-                    'default'     => '',
+					'type'    => 'unzer_additional_key_info',
+					'default' => '',
 				),
 				'public_key_eur_b2c'  => array(
 					'title'   => __( 'Public Key EUR/B2C', 'unzer-payments' ),
@@ -191,14 +191,12 @@ class Installment extends AbstractGateway {
 		}
 
 		if ( $authorization->isSuccess() ) {
-			$order        = wc_get_order( $order_id );
-			$orderService = new OrderService();
-			$orderService->setOrderAuthorized( $order, $authorization->getPayment()->getId() );
+			( new OrderService() )->processPaymentStatus( $authorization, $order );
 		} else {
 			$this->set_order_transaction_number( wc_get_order( $order_id ), $authorization->getPayment()->getId() );
 		}
 		$this->before_payment_redirect( $order_id );
-		$return['redirect'] = $this->get_return_url( wc_get_order( $order_id ) );
+		$return['redirect'] = $authorization->getRedirectUrl() ?: $this->get_confirm_url( wc_get_order( $order_id ) );
 		return $return;
 	}
 	/**

--- a/includes/gateways/Invoice.php
+++ b/includes/gateways/Invoice.php
@@ -66,8 +66,8 @@ class Invoice extends AbstractGateway {
 					'default'     => '',
 				),
 				'additional_key_info' => array(
-					'type' => 'unzer_additional_key_info',
-                    'default'     => '',
+					'type'    => 'unzer_additional_key_info',
+					'default' => '',
 				),
 				'public_key_eur_b2c'  => array(
 					'title'   => __( 'Public Key EUR/B2C', 'unzer-payments' ),
@@ -197,6 +197,7 @@ class Invoice extends AbstractGateway {
 	 * @throws \WC_Data_Exception|Exception
 	 */
 	public function process_payment( $order_id ) {
+		$order  = wc_get_order( $order_id );
 		$return = array(
 			'result' => 'success',
 		);
@@ -217,14 +218,12 @@ class Invoice extends AbstractGateway {
 			throw new Exception( esc_html( $authorization->getMessage()->getCustomer() ) );
 		}
 		if ( $authorization->isSuccess() ) {
-			$order        = wc_get_order( $order_id );
-			$orderService = new OrderService();
-			$orderService->setOrderAuthorized( $order, $authorization->getPayment()->getId() );
+			( new OrderService() )->processPaymentStatus( $authorization, $order );
 		} else {
 			$this->set_order_transaction_number( wc_get_order( $order_id ), $authorization->getPayment()->getId() );
 		}
 		$this->before_payment_redirect( $order_id );
-		$return['redirect'] = $this->get_return_url( wc_get_order( $order_id ) );
+		$return['redirect'] = $authorization->getRedirectUrl() ?: $this->get_confirm_url( wc_get_order( $order_id ) );
 		return $return;
 	}
 

--- a/includes/gateways/OpenBanking.php
+++ b/includes/gateways/OpenBanking.php
@@ -10,8 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class OpenBanking extends AbstractGateway {
 
-	const GATEWAY_ID            = 'unzer_open_banking';
-	const BLOCK_CLASS           = OpenBankingBlock::class;
+	const GATEWAY_ID  = 'unzer_open_banking';
+	const BLOCK_CLASS = OpenBankingBlock::class;
 
 	public $allowedCurrencies   = array( 'EUR' );
 	public $paymentTypeResource = \UnzerSDK\Resources\PaymentTypes\OpenbankingPis::class;

--- a/includes/services/OrderService.php
+++ b/includes/services/OrderService.php
@@ -233,13 +233,36 @@ class OrderService {
 		$logger = ( new LogService() );
 		if ( $transaction instanceof Authorization ) {
 			$logger->debug( 'OrderService::processPaymentStatus() - set authorized' );
-			$this->setOrderAuthorized( $order, $transaction->getPayment()->getId() );
+			if ( $transaction->isPending() ) {
+				$this->logger->debug(
+					'authorization pending',
+					array(
+						'transaction' => $transaction->expose(),
+						'orderId'     => $order->get_id(),
+						'orderAmount' => $order->get_total(),
+					)
+				);
+			} else {
+				$this->setOrderAuthorized( $order, $transaction->getPayment()->getId() );
+			}
 		} else {
-			$logger->debug( 'OrderService::processPaymentStatus() - payment_complete' );
-			$order->payment_complete( $transaction->getPayment()->getId() );
-			$order->set_transaction_id( $transaction->getPayment()->getId() );
-			if ( get_option( 'unzer_captured_order_status' ) ) {
-				$order->set_status( get_option( 'unzer_captured_order_status' ) );
+			if ( $transaction->isPending() ) {
+				$this->logger->debug(
+					'charge pending',
+					array(
+						'transaction' => $transaction->expose(),
+						'orderId'     => $order->get_id(),
+						'orderAmount' => $order->get_total(),
+					)
+				);
+				$order->set_transaction_id( $transaction->getPayment()->getId() );
+			} else {
+				$logger->debug( 'OrderService::processPaymentStatus() - payment_complete' );
+				$order->payment_complete( $transaction->getPayment()->getId() );
+				$order->set_transaction_id( $transaction->getPayment()->getId() );
+				if ( get_option( 'unzer_captured_order_status' ) ) {
+					$order->set_status( get_option( 'unzer_captured_order_status' ) );
+				}
 			}
 			$order->save();
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzer-payments",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Unzer
 Tags: payments, woocommerce
 Requires at least: 4.5
-Tested up to: 6.9
-Stable tag: 2.1.3
+Tested up to: 7.0
+Stable tag: 2.1.4
 License: Apache-2.0
 License URI: http://www.apache.org/licenses/LICENSE-2.0
 Author URI: https://unzer.com
@@ -58,6 +58,11 @@ Personal support via e-mail to support@unzer.com or +49 (6221) 43101-00
 Unzer is one of the leading payment companies in Europe. Over 70,000 retailers trust in the end-to-end solutions for more growth * online, mobile or at the point of sale. Whether international payment processing, risk management or analysis of customer behavior: merchants can put together the data-driven services in a modular way. This means that merchants only need one partner to make their payment future-proof, flexible and innovative.
 
 ## Changelog ##
+
+# 2.1.4 #
+* Direct Bank Transfer order status now correctly derived from combined payment + transaction state, with webhook handling for delayed settlements
+* Fixed UPL 2FA payments bypassing the redirect URL — users are now routed through the 2FA flow before landing on the order success page
+* Verified compatibility with WordPress 7.x
 
 # 2.1.3 #
 * Fixed order button incorrectly displayed alongside Apple Pay and Google Pay

--- a/unzer-payments.php
+++ b/unzer-payments.php
@@ -5,12 +5,12 @@
  * Description: Official Unzer Plugin
  * Author: Unzer
  * Author URI: https://www.unzer.com
- * Version: 2.1.3
+ * Version: 2.1.4
  * License: Apache-2.0
  * Requires at least: 4.5
- * Tested up to: 6.9
+ * Tested up to: 7.0
  * WC requires at least: 6.0
- * WC tested up to: 10.7
+ * WC tested up to: 10.8
  * Text Domain: unzer-payments
  */
 
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'UNZER_VERSION', '2.1.3' );
+define( 'UNZER_VERSION', '2.1.4' );
 define( 'UNZER_PLUGIN_TYPE_STRING', 'Unzer Payments' );
 define( 'UNZER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'UNZER_PLUGIN_PATH', __DIR__ . '/' );


### PR DESCRIPTION
* Direct Bank Transfer order status now correctly derived from combined payment + transaction state, with webhook handling for delayed settlements
* Fixed UPL 2FA payments bypassing the redirect URL — users are now routed through the 2FA flow before landing on the order success page
* Verified compatibility with WordPress 7.x